### PR TITLE
Made standard images animation more smooth

### DIFF
--- a/src/styles/chat-window/navigation/settings-modal.scss
+++ b/src/styles/chat-window/navigation/settings-modal.scss
@@ -247,10 +247,10 @@
         .images {
             display: flex;
             justify-content: space-between;
-            height: 0;
+            max-height: 0;
             opacity: 0;
             overflow: hidden;
-            transition: height 0.5s ease, opacity 0.5s ease, margin 0.5s ease;
+            transition: max-height 0.5s ease, opacity 0.5s ease, margin 0.5s ease;
 
             .img {
                 .dogs-img {
@@ -289,7 +289,7 @@
         .visibility {
             margin-top: 16px;
             opacity: 1;
-            height: auto;
+            max-height: 150px;
         }
     }
 


### PR DESCRIPTION
This is an attempt to make standard images animation in settings more smooth.
The idea is taken from here: https://stackoverflow.com/questions/3508605/how-can-i-transition-height-0-to-height-auto-using-css.
Please verify if the change does not cause any bugs.